### PR TITLE
sourcemap: !production

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -34,7 +34,8 @@ function serve() {
 export default {
 	input: 'src/main.ts',
 	output: {
-		sourcemap: true,
+		//sourcemap: true,
+        sourcemap: !production,
 		format: 'iife',
 		name: 'app',
 		file: 'public/build/bundle.js'


### PR DESCRIPTION
https://stackoverflow.com/questions/63128597/how-to-get-rid-of-the-rollup-plugin-typescript-rollup-sourcemap-option-must